### PR TITLE
fix compilation hacks

### DIFF
--- a/plugin-vslsmashsource.sh
+++ b/plugin-vslsmashsource.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+ghdl HomeOfAviSynthPlusEvolution/L-SMASH-Works build
+cp ../../build-plugins/lwlibav_video.c.patch common
+cd common
+patch -p1 lwlibav_video.c < lwlibav_video.c.patch
+rm lwlibav_video.c.patch
+cd ..
+ghdl l-smash/l-smash
+./configure --prefix="$vsprefix" --extra-cflags="$CFLAGS" || cat config.log
+make -j$JOBS lib
+sudo make install-lib
+cp liblsmash.a ..
+cd ../VapourSynth
+
+#CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson setup build --prefix="$vsprefix" <--- meson.build:1:0: ERROR: prefix value '' must be an absolute path
+CFLAGS="$CFLAGS -Wno-deprecated-declarations" meson setup build --prefix="$HOME/opt/vapoursynth"
+ninja -C build -j $JOBS
+
+cp build/libvslsmashsource.so ../libvslsmashsource.so
+cd ..
+finish libvslsmashsource.so
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Modifying the meson.build is not longer necessary. The pkg-config info (liblsmash.pc) was missing for the liblsmash library. So the build info for meson was not correct. The Run-time dependencies could not be found. You could copy the needed files manually to the right location but a "make install-lib" is much easier. If pkg-config is correct it should look like this:

Found pkg-config: /usr/bin/pkg-config (0.29.2)
Run-time dependency vapoursynth found: YES 66
Run-time dependency liblsmash found: YES 2.16.1 rev.1
Run-time dependency libavcodec found: YES 60.3.100
Run-time dependency libavformat found: YES 60.3.100
Run-time dependency libavutil found: YES 58.2.100
Run-time dependency libswscale found: YES 7.1.100
 Build targets in project: 2
NOTICE: Future-deprecated features used:
 * 0.56.0: {'Dependency.get_pkgconfig_variable'}

L-SMASH-Works undefined

  User defined options
    prefix: /home/user/opt/vapoursynth

Found ninja-1.10.1 at /usr/bin/ninja
ninja: Entering directory `build'
[17/17] Linking target libvslsmashsource.so

Compiling is now working without issues.

Note: With FFmpeg 6.0 patching of lwlibav_video.c is needed because framerate member isn't available there. It's added later.

https://github.com/HomeOfAviSynthPlusEvolution/L-SMASH-Works/issues/18#issuecomment-1793820417

It works "out of the box" without modification with FFmpeg 6.1.